### PR TITLE
Cassandra should listen to the container network interface, so it’s a…

### DIFF
--- a/config/cassandra/cassandra.yaml
+++ b/config/cassandra/cassandra.yaml
@@ -424,9 +424,9 @@ ssl_storage_port: 37001
 # you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4
 # address will be used. If true the first ipv6 address will be used. Defaults to false preferring
 # ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
-listen_address: localhost
-# listen_interface: eth0
-# listen_interface_prefer_ipv6: false
+# listen_address: localhost
+listen_interface: eth0
+listen_interface_prefer_ipv6: false
 
 # Address to broadcast to other Cassandra nodes
 # Leaving this blank will set it to the same value as listen_address
@@ -482,9 +482,9 @@ start_rpc: false
 # you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
 # address will be used. If true the first ipv6 address will be used. Defaults to false preferring
 # ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
-rpc_address: localhost
-# rpc_interface: eth1
-# rpc_interface_prefer_ipv6: false
+# rpc_address: localhost
+rpc_interface: eth0
+rpc_interface_prefer_ipv6: false
 
 # port for Thrift to listen for clients on
 rpc_port: 9160


### PR DESCRIPTION
…ccessible from outside the Docker container.

Please check that it does not mess up the notebook connection (most likely it does, we should modify the metadata to match the container IP or hostname).
