### PR TITLE
One more try to get Cassandra working inside and outside Docker

### DIFF
--- a/config/cassandra/cassandra.yaml
+++ b/config/cassandra/cassandra.yaml
@@ -424,9 +424,9 @@ ssl_storage_port: 37001
 # you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4
 # address will be used. If true the first ipv6 address will be used. Defaults to false preferring
 # ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
-# listen_address: localhost
-listen_interface: eth0
-listen_interface_prefer_ipv6: false
+listen_address: localhost
+#listen_interface: eth0
+#listen_interface_prefer_ipv6: false
 
 # Address to broadcast to other Cassandra nodes
 # Leaving this blank will set it to the same value as listen_address

--- a/devoxx-config.sh
+++ b/devoxx-config.sh
@@ -23,9 +23,6 @@ chmod 600 ~/.ssh/id_rsa
 #nohup service mysql stop
 #echo ...****Ignore the ERROR 2002s Above****...
 
-# IP address eth0
-IP_eth0=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
-
 # Cassandra
 echo ...Configuring Cassandra...
 mv $CASSANDRA_HOME/conf/cassandra-env.sh $CASSANDRA_HOME/conf/cassandra-env.sh.orig

--- a/devoxx-create.sh
+++ b/devoxx-create.sh
@@ -7,9 +7,9 @@ mkdir -p /root/pipeline/logs/spark
 
 echo ...Creating Cassandra Keyspaces Column Families and Tables...
 #cqlsh -e "DROP KEYSPACE IF EXISTS pipeline;"
-cqlsh -e "CREATE KEYSPACE pipeline WITH REPLICATION = { 'class': 'SimpleStrategy',  'replication_factor':1};"
+cqlsh $IP_eth0 -e "CREATE KEYSPACE pipeline WITH REPLICATION = { 'class': 'SimpleStrategy',  'replication_factor':1};"
 #cqlsh -e "USE pipeline; DROP TABLE IF EXISTS real_time_ratings;"
-cqlsh -e "USE pipeline; CREATE TABLE real_time_ratings (fromUserId int, toUserId int, rating int, batchTime bigint, PRIMARY KEY(fromUserId, toUserId));"
+cqlsh $IP_eth0 -e "USE pipeline; CREATE TABLE real_time_ratings (fromUserId int, toUserId int, rating int, batchTime bigint, PRIMARY KEY(fromUserId, toUserId));"
 
 #echo ...Creating Reference Data in Hive...
 ##spark-sql --jars $MYSQL_CONNECTOR_JAR -e 'DROP TABLE IF EXISTS gender_json_file'

--- a/devoxx-setup.sh
+++ b/devoxx-setup.sh
@@ -12,6 +12,9 @@ git reset --hard && git pull
 # Make the scripts executable
 chmod a+rx *.sh
 
+# IP address eth0
+export IP_eth0=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
+
 # Setup tools
 ./devoxx-config.sh
 


### PR DESCRIPTION
One more try to get Cassandra working inside and outside Docker
- rpc_address is bound to `eth0` as before
- listen_address is bound to localhost. This seems to put Cassandra in a one-node config
- cqlsh inside `devoxx-create` are passed the IP_eth0 param
